### PR TITLE
Removed the default attributes for text area

### DIFF
--- a/html5forms/widgets.py
+++ b/html5forms/widgets.py
@@ -7,11 +7,9 @@ from django.utils.html import conditional_escape
 class Html5Textarea(forms.widgets.Textarea):
 
     def __init__(self, attrs=None):
-        # The 'rows' and 'cols' attributes are required for HTML correctness.
-        default_attrs = {'cols': '40', 'rows': '10'}
-        if attrs:
-            default_attrs.update(attrs)
-        super(Html5Textarea, self).__init__(default_attrs)
+        if attrs is None:
+            attrs = {}
+        super(Html5Textarea, self).__init__(attrs)
 
 
     def render(self, name, value, attrs=None):


### PR DESCRIPTION
As of html5 row and col are not required anymore.

As look http://developers.whatwg.org/the-button-element.html#the-textarea-element
"If the rows attribute is specified, its value must be a valid non-negative integer greater than zero."
"If the cols attribute is specified, its value must be a valid non-negative integer greater than zero."
