### PR TITLE
python 2/3 compatible and fix broken tests

### DIFF
--- a/.lgtm
+++ b/.lgtm
@@ -1,0 +1,2 @@
+pattern = "(?i):shipit:|👍|\\+1|:\\+1:|LGTM"
+approvals = 2

--- a/html5forms/fields.py
+++ b/html5forms/fields.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from django import forms
 from django.utils import formats
 from django.core.exceptions import ValidationError

--- a/html5forms/fields.py
+++ b/html5forms/fields.py
@@ -1,13 +1,14 @@
 from django import forms
 from django.utils import formats
 from django.core.exceptions import ValidationError
-from widgets import Html5TextInput, Html5PasswordInput, Html5CheckboxInput
-from widgets import Html5SearchInput, Html5EmailInput, Html5Select, Html5TelInput
-from widgets import Html5URLInput, Html5NumberInput, Html5RangeInput
+from .widgets import Html5TextInput, Html5PasswordInput, Html5CheckboxInput
+from .widgets import Html5SearchInput, Html5EmailInput, Html5Select, Html5TelInput
+from .widgets import Html5URLInput, Html5NumberInput, Html5RangeInput
 from django.core import validators, exceptions
-from django.utils.encoding import smart_unicode
+from django.utils.encoding import smart_text
 from django.utils.translation import ugettext_lazy as _
-import urlparse
+import six
+import six.moves.urllib.parse as urlparse
 
 
 __all__ = (
@@ -51,7 +52,7 @@ class Html5Field(forms.fields.Field):
             widget_attrs['required'] = None
             current_class.append('required')
 
-        if isinstance(self.class_attr, (str, unicode)):
+        if isinstance(self.class_attr, six.string_types):
             self.class_attr = self.class_attr.split()
 
         for classitem in self.class_attr:
@@ -129,7 +130,7 @@ class Html5CharField(Html5Field):
     def to_python(self, value):
         if value in validators.EMPTY_VALUES:
             return u''
-        return smart_unicode(value)
+        return smart_text(value)
 
     def widget_attrs(self, widget):
         par_attrs = super(Html5CharField, self).widget_attrs(widget)
@@ -375,7 +376,7 @@ class Html5ChoiceField(Html5Field):
         "Returns a Unicode object."
         if value in validators.EMPTY_VALUES:
             return u''
-        return smart_unicode(value)
+        return smart_text(value)
 
     def validate(self, value):
         """
@@ -392,9 +393,9 @@ class Html5ChoiceField(Html5Field):
                 # This is an optgroup, so look inside the group for options
                 for x in v:
                     k2 = x[0]
-                    if value == smart_unicode(k2):
+                    if value == smart_text(k2):
                         return True
             else:
-                if value == smart_unicode(k):
+                if value == smart_text(k):
                     return True
         return False

--- a/html5forms/fields.py
+++ b/html5forms/fields.py
@@ -40,17 +40,17 @@ class Html5Field(forms.fields.Field):
         super(Html5Field, self).__init__(*args, **kwargs)
 
     def widget_attrs(self, widget):
-        widget_attrs = super(Html5Field, self).widget_attrs(widget)
-        current_class = widget_attrs.get('class', '').split()
+        _widget_attrs = super(Html5Field, self).widget_attrs(widget)
+        current_class = _widget_attrs.get('class', '').split()
 
         if self.placeholder:
-            widget_attrs['placeholder'] = self.placeholder
+            _widget_attrs['placeholder'] = self.placeholder
 
         if self.autofocus:
-            widget_attrs['autofocus'] = None
+            _widget_attrs['autofocus'] = None
 
         if self.required:
-            widget_attrs['required'] = None
+            _widget_attrs['required'] = None
             current_class.append('required')
 
         if isinstance(self.class_attr, six.string_types):
@@ -61,9 +61,9 @@ class Html5Field(forms.fields.Field):
                 current_class.append(classitem)
 
         if current_class:
-            widget_attrs['class'] = ' '.join(current_class)
+            _widget_attrs['class'] = ' '.join(current_class)
 
-        return widget_attrs
+        return _widget_attrs
 
 
 class Html5BooleanField(Html5Field):
@@ -85,15 +85,15 @@ class Html5BooleanField(Html5Field):
         return value
 
     def widget_attrs(self, widget):
-        widget_attrs = {}
+        _widget_attrs = {}
 
         if self.autofocus:
-            widget_attrs['autofocus'] = None
+            _widget_attrs['autofocus'] = None
 
         if self.required:
-            widget_attrs['required'] = None
+            _widget_attrs['required'] = None
 
-        return widget_attrs
+        return _widget_attrs
 
 
 class Html5CharField(Html5Field):

--- a/html5forms/tests.py
+++ b/html5forms/tests.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from xml.etree import ElementTree
+
 from django.test import TestCase
+
 from html5forms import Form
 from html5forms.fields import *
 
@@ -60,10 +62,9 @@ class TestCharField(TestCase):
 
     def test_html_output(self):
         form = self.form_class({'field':'**'})
-        self.assertIn('maxlength="20"', form['field'])
-        self.assertIn('autofocus', form['field'])
-        self.assertIn(' required ', form['field'])
-        self.assertIn('class="required test-class"', form['field'])
+        value = str(form['field'])
+        for exp in ['maxlength="20"', 'autofocus', ' required ', 'class="required test-class"']:
+            self.assertIn(exp, value)
 
 
 class TestIntegerField(TestCase):

--- a/html5forms/tests.py
+++ b/html5forms/tests.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
+from xml.etree import ElementTree
 from django.test import TestCase
 from html5forms import Form
 from html5forms.fields import *
+
 
 class TestBooleanField(TestCase):
     def setUp(self):
@@ -28,8 +30,16 @@ class TestBooleanField(TestCase):
 
     def test_form(self):
         form = self.form_class({'field':'t'})
-        self.assertEqual(form['field'],
-            '<input checked="checked" type="checkbox" name="field" value="t" id="id_field" />')
+        expected = '<input checked="checked" type="checkbox" name="field" value="t" id="id_field" />'
+        to_compare = [expected, str(form['field'])]
+        self.assertEqual(*(self._standardize_xml(xmlstr) for xmlstr in to_compare))
+
+    @staticmethod
+    def _standardize_xml(string):
+        """ Returns a standard string representation of an ElementTree xml node given an xml string. """
+        return ElementTree.tostring(
+            ElementTree.fromstring(string)
+        )
 
 
 class TestCharField(TestCase):

--- a/html5forms/tests.py
+++ b/html5forms/tests.py
@@ -15,7 +15,7 @@ class TestBooleanField(TestCase):
         form = self.form_class({'field':'False'})
         self.assertTrue(form.is_valid())
         self.assertFalse(form.cleaned_data['field'])
-    
+
     def test_false2(self):
         form = self.form_class({'field':'0'})
         self.assertTrue(form.is_valid())
@@ -28,7 +28,7 @@ class TestBooleanField(TestCase):
 
     def test_form(self):
         form = self.form_class({'field':'t'})
-        self.assertEqual(unicode(form['field']), 
+        self.assertEqual(form['field'],
             '<input checked="checked" type="checkbox" name="field" value="t" id="id_field" />')
 
 
@@ -43,17 +43,17 @@ class TestCharField(TestCase):
     def test_length(self):
         form = self.form_class({'field':'*'*20})
         self.assertTrue(form.is_valid())
-    
+
     def test_length2(self):
         form = self.form_class({'field':'*'*21})
         self.assertFalse(form.is_valid())
 
     def test_html_output(self):
         form = self.form_class({'field':'**'})
-        self.assertIn('maxlength="20"', unicode(form['field']))
-        self.assertIn('autofocus', unicode(form['field']))
-        self.assertIn(' required ', unicode(form['field']))
-        self.assertIn('class="required test-class"', unicode(form['field']))
+        self.assertIn('maxlength="20"', form['field'])
+        self.assertIn('autofocus', form['field'])
+        self.assertIn(' required ', form['field'])
+        self.assertIn('class="required test-class"', form['field'])
 
 
 class TestIntegerField(TestCase):

--- a/html5forms/widgets.py
+++ b/html5forms/widgets.py
@@ -1,8 +1,8 @@
 from django import forms
 from django.utils.safestring import mark_safe
-from django.utils.encoding import force_unicode, force_text
+from django.utils.encoding import force_text
 from django.utils.html import format_html
-from util import flatatt, render_datalist
+from .util import flatatt, render_datalist
 from django.utils.html import conditional_escape
 
 
@@ -19,7 +19,7 @@ class Html5Textarea(forms.widgets.Textarea):
         final_attrs = self.build_attrs(attrs, name=name)
 
         return mark_safe(u'<textarea%s>%s</textarea>' % (flatatt(final_attrs),
-                conditional_escape(force_unicode(value))))
+                conditional_escape(force_text(value))))
 
 
 class Html5TextInput(forms.widgets.TextInput):
@@ -31,10 +31,10 @@ class Html5TextInput(forms.widgets.TextInput):
 
         if value != '':
             # Only add the 'value' attribute if a value is non-empty.
-            final_attrs['value'] = force_unicode(self._format_value(value))
+            final_attrs['value'] = force_text(self._format_value(value))
         if getattr(self, 'datalist', None) and isinstance(self.datalist, (tuple, list)):
             datalist_name = u'%s_datalist' % name
-            final_attrs['list'] = force_unicode(u'%s_datalist' % name)
+            final_attrs['list'] = force_text(u'%s_datalist' % name)
             return mark_safe(u"""<input%s >%s"""
                     % (flatatt(final_attrs),
                         render_datalist(datalist_name, self.datalist)))
@@ -63,7 +63,7 @@ class Html5CheckboxInput(forms.widgets.CheckboxInput):
             final_attrs['checked'] = 'checked'
         if value not in ('', True, False, None):
             # Only add the 'value' attribute if a value is non-empty.
-            final_attrs['value'] = force_unicode(value)
+            final_attrs['value'] = force_text(value)
         return mark_safe(u'<input%s />' % flatatt(final_attrs))
 
 
@@ -105,7 +105,7 @@ class Html5Select(forms.Select):
                 selected_choices.remove(option_value)
         selected_html = mark_safe(selected_html)
         return format_html(u'<option value="{0}"{1}>{2}</option>',
-                option_value, selected_html, force_unicode(option_label))
+                option_value, selected_html, force_text(option_label))
 
 class Html5TelInput(Html5TextInput):
     input_type = 'tel'

--- a/html5forms/widgets.py
+++ b/html5forms/widgets.py
@@ -67,6 +67,12 @@ class Html5CheckboxInput(forms.widgets.CheckboxInput):
             final_attrs['value'] = force_text(value)
         return mark_safe(u'<input%s />' % flatatt(final_attrs))
 
+    def value_from_datadict(self, data, files, name):
+        value = data.get(name, None)
+        if value in ('False', '0'):
+            value = False
+        return value
+
 
 class Html5SearchInput(Html5TextInput):
     input_type = 'search'

--- a/html5forms/widgets.py
+++ b/html5forms/widgets.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from django import forms
 from django.utils.safestring import mark_safe
 from django.utils.encoding import force_text

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except:
 
 
 setup(name='html5forms',
-      version='0.0.3',
+      version='0.0.4',
       packages=find_packages(),
       author=u'Adam Cupiał',
       url='https://github.com/adamcupial/django-html5-forms',

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ setup(name='html5forms',
       description=DESCRIPTION,
       long_description=LONG_DESCRIPTION,
       platforms=['any'],
+      install_requires=(
+          'six',
+      ),
       classifiers=[
           'Development Status :: 4 - Beta',
           'Intended Audience :: Developers',


### PR DESCRIPTION
Two tests were failing on python 2.7 (I think at least one of these had to do with changes introduced to django in version 1.5).  This fixes those tests and builds on the python 3 compatibility work of "Tadas Dailyda" (tadas@dailyda.com), making the library python 3 compatible (tested on python 2.7 and 3.4).

If you approve, please release a new version of the package to pypi ASAP, since we'd like to use this package in production with python 3.  Thanks!!
